### PR TITLE
Added FastQL to Gateways section

### DIFF
--- a/src/toolsData.js
+++ b/src/toolsData.js
@@ -117,6 +117,13 @@ export default {
         url: "https://www.apollographql.com/engine",
         github: "https://github.com/apollographql/apollo-engine-js",
         language: JavaScript
+      },
+      {
+        name: "FastQL",
+        description:
+          "FastQL is a GraphQL CDN and API gateway. Improves performance by caching GraphQL API results at the edge and automatically invalidates stale caches.",
+        url: "https://fastql.io",
+        language: Go
       }
     ]
   },


### PR DESCRIPTION
Added FastQL to Gateways section. FastQL is a CDN built specifically for GraphQL. I'm the founder so feel free to ask any questions :)