### PR TITLE
Clarify Database-to-GraphQL Servers

### DIFF
--- a/src/toolsData.js
+++ b/src/toolsData.js
@@ -303,9 +303,9 @@ export default {
     ]
   },
   dbProxy: {
-    name: "Database Helpers",
+    name: "Database-to-GraphQL Servers",
     description:
-      "These tools sit above one or more databases in the data layer. They help by providing boilerplate functionality (such as CRUD operations). They might also act like an ORM for a database.",
+      "These tools sit above one or more databases and translate between the database and GraphQL. Some can serve GraphQL clients directly, some might act like an ORM for a database. They typically offer boilerplate functionality (such as CRUD operations), and some expose more powerful database features.",
     tools: [
       {
         name: "Prisma",
@@ -317,7 +317,7 @@ export default {
       {
         name: "PostGraphile",
         description:
-          "Instant, secure and fast GraphQL API for your Postgres database.",
+          "Instant client-facing GraphQL server for your existing Postgres database, secured through Postgres' advanced access-control features. Highly customizable and extensible via SQL, Foreign Data Wrappers, and JS plugins.",
         url: "https://www.graphile.org/postgraphile/",
         github: "https://github.com/graphile/postgraphile"
       }


### PR DESCRIPTION
PostGraphile is a bit more sophisticated than implied previously - it can serve GraphQL clients directly (using JWT or cookie sessions for authentication and PostgreSQL's access-control features for authorization) and supports a lot more than just boilerplate CRUD functionality. To make this clearer, I've renamed the bottom section from "Database Helpers" to "Database-to-GraphQL Servers" and amended its description. I'm keen to get your feedback on these changes.

Before:

![screenshot 2018-06-12 17 38 03](https://user-images.githubusercontent.com/129910/41304217-6fed8e0e-6e67-11e8-8231-ed0a67ea8ccf.png)


After:

![screenshot 2018-06-12 17 38 21](https://user-images.githubusercontent.com/129910/41304223-7370f00c-6e67-11e8-8b73-0028325e8d30.png)
